### PR TITLE
docker friendly configuration

### DIFF
--- a/device/config.py
+++ b/device/config.py
@@ -49,11 +49,28 @@ import logging
 #
 _dict = {}
 _dict = toml.load(f'{sys.path[0]}/config.toml')    # Errors here are fatal.
+_dict2 = {}
+try:
+    # ltf - this file, if it exists can override or supplement definitions in the normal config.tom.
+    # this facilitates putting the driver in a docker container where installation specific
+    # configuration can be put in a file that isn't pulled from a repository
+    _dict2 = toml.load('/alpyca/config.toml')
+except:
+    _dict2 = {}
+    # file is optional so it's ok if it isn't there
+
 def get_toml(sect: str, item: str):
-    if not _dict is {}:
-        return _dict[sect][item]
-    else:
-        return ''
+    setting = ''
+    s = None
+    try:
+        setting = _dict2[sect][item]
+    except:
+        try:
+            setting = _dict[sect][item]
+        except:
+            setting = ''
+
+    return setting
 
 class Config:
     """Device configuration in ``config.toml``"""
@@ -70,9 +87,21 @@ class Config:
     # --------------
     # Device Section
     # --------------
-    can_reverse: bool = get_toml('device', 'can_reverse')
-    step_size: float = get_toml('device', 'step_size')
-    steps_per_sec: int = get_toml('device', 'steps_per_sec')
+    mqtt_server: str = get_toml('device', 'mqtt_server')
+    mqtt_port: int = get_toml('device', 'mqtt_port') 
+    mqtt_user: str = get_toml('device', 'mqtt_user')
+    mqtt_password: str = get_toml('device', 'mqtt_password')
+    topic_cloud_cover: str  = get_toml('device', 'topic_cloud_cover')
+    topic_dew_point: str = get_toml('device', 'topic_dew_point')
+    topic_event_rain: str = get_toml('device', 'topic_event_rain')
+    topic_humidity: str = get_toml('device', 'topic_humidity')
+    topic_pressure: str = get_toml('device', 'topic_pressure')
+    topic_solar_radiation: str = get_toml('device', 'topic_solar_radiation')
+    topic_sqm: str = get_toml('device', 'topic_sqm')
+    topic_temperature: str = get_toml('device', 'topic_temperature')
+    topic_wind_direction: str = get_toml('device', 'topic_wind_direction')
+    topic_wind_gust: str = get_toml('device', 'topic_wind_gust')
+    topic_wind_speed: str = get_toml('device', 'topic_wind_speed')
     # ---------------
     # Logging Section
     # ---------------


### PR DESCRIPTION
I wrote an Alpaca driver using AlpacaDevice that runs in a docker container. It takes weather and sky quality data that was already on a Mosquito server on my network and makes it available to ASCOM. In my case the weather data is coming from an Ambient Weather WS-2000 weather station, cloud data is coming from the Aeris Weather API and sky quality data is coming from a Unihedron sky quality meter. 

In order to keep private configuration data out of a public repository (MQTT server name, user name and password), I wanted to put that data into a local configuration file that would be attached to the docker container as a volume. I updated config.py to look for a file /alpyca/config.toml (this would be the pathname used inside the container) that would override or supplement the values in the default config.toml file. 

I thought this might be useful for others so am sending it back as a possible contribution to the project.